### PR TITLE
Container test scripts

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,6 +12,7 @@ WORKDIR /home/comfy
 
 # Copy the binary into the container
 COPY --chown=comfy:comfy bin/dotcomfy bin/dotcomfy
+COPY --chown=comfy:comfy tests/scripts/* tests/scripts/
 
 # TODO: Copy test scenarios that are wrapped as bash scripts
 

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,32 @@ container: build-container
 	$(CONTAINER_RUNTIME) run --rm -it $(IMAGE_NAME):$(IMAGE_TAG)
 
 .PHONY: container
+
+TEST_DIR := tests/scripts
+
+check-test:
+	@if [ ! -f $(TEST_DIR)/$(TEST_SCRIPT) ]; then \
+		echo "Error: Test script $(TEST_DIR)/$(TEST_SCRIPT) not found!"; \
+		exit 1; \
+	fi
+
+.PHONY: check-test
+
+.PHONY: test-%
+
+# Running `test-install` will run `tests/scripts/install.sh` from inside the
+# container.
+test-%:
+	$(MAKE) TEST_SCRIPT=$*.sh check-test build-container
+	@echo "Running test $*.sh in container ..."
+	$(CONTAINER_RUNTIME) run --rm $(IMAGE_NAME):$(IMAGE_TAG) bash $(TEST_DIR)/$*.sh
+
+# This runs all the test scripts
+test:
+	@for test in $(wildcard $(TEST_DIR)/*.sh); do \
+		@echo $$test; \
+		test_name=$$(basename $$test .sh); \
+		$(MAKE) test-$$test_name; \
+	done
+
+.PHONY: test

--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Description: Basic test emulating installing a repo
+
+set -xeuv
+
+./bin/dotcomfy install https://gitlab.com/reavessm/dot-files


### PR DESCRIPTION
Allows you to run `make test-install` and run `tests/scripts/install.sh` inside of a container