### PR TITLE
Don't fail if nothing to delete in old_path

### DIFF
--- a/internal/services/remove_installation.go
+++ b/internal/services/remove_installation.go
@@ -25,19 +25,16 @@ func RemoveInstallation(dotcomfy_dir, old_dotfiles_dir string) (err error) {
 					// Remove symlink
 					err = os.Remove(old_path)
 					if err != nil {
-						LOGGER.Error(err)
-						return err
+						LOGGER.Warn(err)
 					}
 					err = os.Rename(old_path, old_name)
 					if err != nil {
-						LOGGER.Error(err)
-						return err
+						LOGGER.Warn(err)
 					}
 				} else { // Just remove symlink
 					err = os.Remove(old_path)
 					if err != nil {
-						LOGGER.Error(err)
-						return err
+						LOGGER.Warn(err)
 					}
 				}
 			}


### PR DESCRIPTION
This fixes a bug that occurs if `old_path` does not exist. Previously, the program would throw a fatal error, but since it's not a big deal if a file is in `.dotcomfy` and not `.config`, this should just be a warning.

This shouldn't ever really happen, so maybe I'll revisit this in the future, but for now (so I can use dotcomfy for myself without a big headache), I'm just treating this as a warning.