### PR TITLE
Fix/pull symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 ## Features
 
-- **One-command installation** of config sets for various developer tools.
-- **Config switching** between different setups or environments.
-- **Automated dependency management** for packages required by your configs.
-- **Customizable installation scripts** for tools without standard package management.
+- One-command installation of config sets for various developer tools.
+- Config switching between different setups or environments.
+- Automated dependency management for packages required by your configs.
+- Customizable installation scripts for tools without standard package management.
 
 ### Note
 The dependency management feature is still in development and may not work as expected.
@@ -57,29 +57,41 @@ This will build the binary and install it to `/usr/local/bin/`.
 
 ## Configuration
 
-dotcomfy's config file lives at `$HOME/.config/dotcomfy/config.toml`.
+dotcomfy's config file lives at `$HOME/.config/dotcomfy/config.yaml`.
 
 ### Dependencies
 
 You can specify packages that need to be installed in order for the config set to function properly:
-```toml filename="config.toml"
-[dependencies]
+```yaml filename="config.yaml"
+dependencies:
 # Version can be specified for a package being installed from a package manager
-fzf = { version = "0.57.0" }
-# Custom shell scripts for dependency installation can be specified.
-# The `needs` field can be used to specify dependencies that need to be installed before this dependency.
-nvim = { script = "nvim.sh", needs = ["zsh"] }
-# Custom installations can be specified step by step
-nvm = { steps = [ "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash", "source ~/.zshrc" ], needs = ["zsh"] }
-tmux = { version = "latest" }
-# Commands needed after package installation can also be specified
-zsh = { post_install_steps = [ "chsh -s $(which zsh)" ] }
+  fzf:
+    version: 0.57.0
+  # Custom shell scripts for dependency installation can be specified.
+  # The `needs` field can be used to specify dependencies that need to be installed before this dependency.
+  nvim:
+    script: nvim.sh
+    needs:
+      - zsh
+  # Custom installations can be specified step by step
+  nvm:
+    steps:
+      - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+    needs:
+      - zsh
+  tmux:
+    version: latest
+  # Commands needed after package installation can also be specified
+  zsh:
+    post_install_steps:
+      - chsh -s $(which zsh)
 ```
+
 #### Custom Installation Scripts
 
 Scripts should start with `#!/bin/sh` and should be located in the same directory as the config file.
 ```sh filename="nvim.sh"
-#!/bin/bash
+#!/bin/sh
 
 curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
 sudo rm -rf /opt/nvim

--- a/cmd/dotcomfy/cobra/install.go
+++ b/cmd/dotcomfy/cobra/install.go
@@ -86,7 +86,10 @@ func run(cmd *cobra.Command, args []string) {
 		}
 
 		if !d.IsDir() && !strings.Contains(path, ".git") && !strings.Contains(path, "README.md") {
-			_, err = services.RenameSymlinkUnix(old_dotfiles_dir, dotcomfy_dir, path)
+			// center_path represents the path of the directory entry
+			// with the dotcomfy_path prefix removed.
+			center_path := strings.TrimPrefix(path, dotcomfy_dir)
+			_, err = services.RenameSymlinkUnix(old_dotfiles_dir, dotcomfy_dir, center_path)
 			if err != nil {
 				LOGGER.Error(err)
 				return err

--- a/cmd/dotcomfy/cobra/pull.go
+++ b/cmd/dotcomfy/cobra/pull.go
@@ -13,14 +13,14 @@ import (
 	"dotcomfy/internal/services"
 )
 
-// syncCmd represents the sync command
-var syncCmd = &cobra.Command{
-	Use:   "sync",
+// pullCmd represents the pull command
+var pullCmd = &cobra.Command{
+	Use:   "pull",
 	Short: "Syncs your dotcomfy installation with the remote repository",
 	Long: `This command will pull the latest changes from the remote repository
 and update your dotcomfy installation accordingly.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("sync called")
+		fmt.Println("pull called")
 		LOGGER = Log.GetLogger()
 		user, err := user.Current()
 		if err != nil {
@@ -35,29 +35,8 @@ and update your dotcomfy installation accordingly.`,
 	},
 }
 
-var pushCmd = &cobra.Command{
-	Use:   "push",
-	Short: "Pushes your local changes",
-	Long: `Pushes your local changes to the remote repository on the current
-branch. Note that you must have write permissions for this to succeed.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("push called")
-
-		/*
-			LOGGER = Log.GetLogger()
-			user, err := user.Current()
-			if err != nil {
-				LOGGER.Fatal(err)
-			}
-			dotcomfy_dir := user.HomeDir + "/.dotcomfy"
-		*/
-	},
-}
-
 func init() {
-	rootCmd.AddCommand(syncCmd)
-
-	syncCmd.AddCommand(pushCmd)
+	rootCmd.AddCommand(pullCmd)
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/dotcomfy/cobra/push.go
+++ b/cmd/dotcomfy/cobra/push.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cobra
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+
+	"github.com/spf13/cobra"
+
+	Log "dotcomfy/internal/logger"
+	"dotcomfy/internal/services"
+)
+
+// pushCmd represents the push command
+var pushCmd = &cobra.Command{
+	Use:   "push",
+	Short: "Pushes your local changes",
+	Long: `Pushes your local changes to the remote repository on the current
+branch. Note that you must have write permissions for this to succeed.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("push called")
+
+		LOGGER = Log.GetLogger()
+		user, err := user.Current()
+		if err != nil {
+			LOGGER.Fatal(err)
+		}
+		dotcomfy_dir := user.HomeDir + "/.dotcomfy"
+		err = services.Push(dotcomfy_dir)
+		if err != nil {
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pushCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// syncCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// syncCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,10 +118,12 @@ func (c *Config) SetDependencyNames() {
 	c.Dependencies = newDependencies
 }
 
+// TODO: I need to do error handling on these getters since they may not exist
 type Auth struct {
-	Username    string `toml:username,omitempty`
-	Email       string `toml:email,omitempty`
-	SSHFilePath string `toml:ssh_file,omitempty`
+	Username         string `toml:username,omitempty`
+	Email            string `toml:email,omitempty`
+	SSHKeyPath       string `toml:ssh_file,omitempty`
+	SSHKeyPassphrase string `toml:ssh_key_passphrase,omitempty`
 }
 
 func (g *Auth) GetUsername() string {
@@ -132,8 +134,12 @@ func (g *Auth) GetEmail() string {
 	return g.Email
 }
 
-func (g *Auth) GetSSHFilePath() string {
-	return g.SSHFilePath
+func (g *Auth) GetSSHKeyPath() string {
+	return g.SSHKeyPath
+}
+
+func (g *Auth) GetSSHKeyPassphrase() string {
+	return g.SSHKeyPassphrase
 }
 
 type Dependency struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,8 +215,8 @@ func SetConfig() {
 		LOGGER.Fatal(err)
 	}
 	viper.AddConfigPath(cfg + "/dotcomfy/") // Config file lives in $HOME/.config/dotcomfy/
-	viper.SetConfigName("config.toml")
-	viper.SetConfigType("toml")
+	viper.SetConfigName("config.yaml")
+	viper.SetConfigType("yaml")
 	err = viper.ReadInConfig()
 	if err != nil {
 		LOGGER.Error(err)

--- a/internal/services/git.go
+++ b/internal/services/git.go
@@ -102,7 +102,6 @@ func Pull(repo_path string) error {
 	}
 
 	remote_ref_name := plumbing.NewRemoteReferenceName("origin", branch_name)
-	fmt.Println("remote ref name:", remote_ref_name)
 	origin_ref, err := repo.Reference(remote_ref_name, true)
 	if err != nil {
 		LOGGER.Errorf("Error getting origin reference: %v", err)
@@ -110,7 +109,6 @@ func Pull(repo_path string) error {
 	}
 
 	remote_commit, err := repo.CommitObject(origin_ref.Hash())
-	fmt.Println("remote commit:", remote_commit)
 	if err != nil {
 		LOGGER.Errorf("Error getting origin commit hash: %v", err)
 		return err
@@ -123,7 +121,6 @@ func Pull(repo_path string) error {
 	}
 
 	local_ref_name := plumbing.NewBranchReferenceName(branch_name)
-	fmt.Println("local ref name:", local_ref_name)
 	local_ref, err := repo.Reference(local_ref_name, true)
 	if err != nil {
 		LOGGER.Errorf("Error getting local reference: %v", err)
@@ -131,7 +128,6 @@ func Pull(repo_path string) error {
 	}
 
 	local_commit, err := repo.CommitObject(local_ref.Hash())
-	fmt.Println("local commit:", local_commit)
 	if err != nil {
 		LOGGER.Errorf("Error getting local commit hash: %v", err)
 		return err
@@ -149,7 +145,7 @@ func Pull(repo_path string) error {
 		return err
 	}
 
-	LOGGER.Errorf("Origin ref after fetch: %s", origin_ref.Hash())
+	LOGGER.Infof("Origin ref after fetch: %s", origin_ref.Hash())
 
 	branch := plumbing.NewBranchReferenceName(branch_name)
 	// Bypass dirty worktree checks and just "fast forward" to the latest commit
@@ -192,8 +188,8 @@ func Pull(repo_path string) error {
 		return err
 	}
 
-	fmt.Printf("HEAD is now at %s\n", head.Hash())
-	fmt.Println("Changes from local to remote HEAD:")
+	LOGGER.Infof("HEAD is now at %s\n", head.Hash())
+	LOGGER.Infof("Changes from local to remote HEAD:")
 
 	for _, change := range changes {
 		action, err := change.Action()

--- a/internal/services/git.go
+++ b/internal/services/git.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"os/user"
+	// "os/user"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -151,9 +151,10 @@ func Pull(repo_path string) error {
  * TODO: Specify branch to push to   *
  *************************************/
 func Push(repo_path string) error {
-	var repo_url string
+	LOGGER = Log.GetLogger()
+	// var repo_url string
 	var branch string
-	var failed_files []string
+	// var failed_files []string
 
 	config := Config.GetConfig()
 	auth := config.Auth
@@ -175,19 +176,15 @@ func Push(repo_path string) error {
 		return err
 	}
 
-	remote, err := repo.Remote("origin")
-	if err != nil {
-		LOGGER.Error("Error getting remote from the origin:", err)
-		return err
-	}
-
 	// Grab URL to be pushed to? Do I need this?
-	urls := remote.Config().URLs
-	if len(urls) > 0 {
-		repo_url = urls[0]
-	} else {
-		LOGGER.Fatal("No URL found for the remote 'origin'")
-	}
+	/*
+		urls := remote.Config().URLs
+		if len(urls) > 0 {
+			repo_url = urls[0]
+		} else {
+			LOGGER.Fatal("No URL found for the remote 'origin'")
+		}
+	*/
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -249,6 +246,12 @@ func Push(repo_path string) error {
 		LOGGER.Fatalf("Error committing: %v", err)
 	}
 
+	remote, err := repo.Remote("origin")
+	if err != nil {
+		LOGGER.Error("Error getting remote from the origin:", err)
+		return err
+	}
+
 	// TODO:
 	// Set up auth for private repos and/or username/password auth at runtime
 	// var auth *http.BasicAuth
@@ -256,7 +259,7 @@ func Push(repo_path string) error {
 
 	// }
 
-	err = repo.Push(&git.PushOptions{
+	err = remote.Push(&git.PushOptions{
 		Auth:       ssh_auth,
 		RemoteName: "origin",
 		Progress:   os.Stdout,

--- a/internal/services/rename_symlink.go
+++ b/internal/services/rename_symlink.go
@@ -3,7 +3,6 @@ package services
 import (
 	"os"
 	"path/filepath"
-	"strings"
 
 	Log "dotcomfy/internal/logger"
 )
@@ -11,13 +10,9 @@ import (
 // TODO:
 //
 // write documentation
-// change `new_path` param to just be `center_path`, performing the TrimPrefix in code before calling this function.
-// for `new_path` var in the below function, just add `dotcomfy_dir` as a prefix
-func RenameSymlinkUnix(old_dotfiles_dir, dotcomfy_dir, new_path string) (string, error) {
+func RenameSymlinkUnix(old_dotfiles_dir, dotcomfy_dir, center_path string) (string, error) {
 	LOGGER = Log.GetLogger()
-	// center_path represents the path of the directory entry
-	// with the dotcomfy_path prefix removed.
-	center_path := strings.TrimPrefix(new_path, dotcomfy_dir)
+	new_path := dotcomfy_dir + center_path
 	old_path := old_dotfiles_dir + center_path
 	// Want to check to see if new_entry has a corresponding entry
 	// in old_dotfiles_path. If so, rename corresponding entry to

--- a/internal/services/rename_symlink.go
+++ b/internal/services/rename_symlink.go
@@ -8,7 +8,11 @@ import (
 	Log "dotcomfy/internal/logger"
 )
 
-// TODO: write documentation
+// TODO:
+//
+// write documentation
+// change `new_path` param to just be `center_path`, performing the TrimPrefix in code before calling this function.
+// for `new_path` var in the below function, just add `dotcomfy_dir` as a prefix
 func RenameSymlinkUnix(old_dotfiles_dir, dotcomfy_dir, new_path string) (string, error) {
 	LOGGER = Log.GetLogger()
 	// center_path represents the path of the directory entry


### PR DESCRIPTION
Merging in a few changes, some in progress, but I needed to provide a fix for `pull`:

# Changes
- Switched config file format from TOML to YAML
- Updated README
- `pull`/`push` are now their own commands instead of being subcommands of `sync`
- Refactored `rename_symlink` a bit to accommodate for usage when `pull` gets new files from the upstream repository
- Working on `push` for SSH authorization to Git repo